### PR TITLE
Allow configurable Kroki URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ The site remains truly static as the SVG is directly embedded in the HTML files 
 
 `jekyll-kroki` uses the same Markdown fenced code syntax as the [GitLab Kroki integration](https://docs.gitlab.com/ee/administration/integration/kroki.html), allowing diagram descriptions in Markdown files to be displayed seamlessly in both the GitLab UI and on GitLab Pages sites generated using Jekyll.
 
+### Configuration
+
+You can specify the URL of the Kroki instance to use in the Jekyll `_config.yml` file:
+
+```yaml
+jekyll-kroki:
+  kroki_url: "https://my-kroki.server"
+```
+
+This is useful if you want to run a Kroki instance locally or your organisation maintains its own private Kroki server. `jekyll-kroki` will use the public Kroki instance https://kroki.io by default if a URL is not specified.
+
 ## Contributing
 
 Bug reports and pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -96,7 +96,7 @@ module Jekyll
       def kroki_url(config)
         if config.key?("jekyll-kroki") && config["jekyll-kroki"].key?("kroki_url")
           url = config["jekyll-kroki"]["kroki_url"]
-          raise "'kroki_url' is not a valid HTTP URL" unless URI.parse(url).is_a?(URI::HTTP)
+          raise TypeError, "'kroki_url' is not a valid HTTP URL" unless URI.parse(url).is_a?(URI::HTTP)
 
           URI(url)
         else

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -10,25 +10,27 @@ require "nokogiri"
 require "zlib"
 
 module Jekyll
-  # Jekyll plugin for the Kroki diagram engine
+  # Converts diagram descriptions into images using Kroki
   class Kroki
-    KROKI_INSTANCE_URL = "https://kroki.io"
+    KROKI_DEFAULT_URL = "https://kroki.io"
 
     class << self
       # Renders all diagram descriptions written in a Kroki-supported language in an HTML document.
       #
       # @param [Jekyll::Page or Jekyll::Document] The document to render diagrams in
       def render(doc)
-        puts "Rendering diagrams using Kroki"
+        # Get the URL of the Kroki instance
+        kroki_url = kroki_url(doc.site.config)
+        puts "[jekyll-kroki] Rendering diagrams in '#{doc.name}' using '#{kroki_url}'"
 
         # Parse the HTML document
         parsed_doc = Nokogiri::HTML.parse(doc.output)
 
         # Iterate through every diagram description in each of the supported languages
-        get_supported_languages(KROKI_INSTANCE_URL).each do |language|
+        get_supported_languages(kroki_url).each do |language|
           parsed_doc.css("code[class~='language-#{language}']").each do |diagram_desc|
             # Get the rendered diagram using Kroki
-            rendered_diagram = render_diagram(KROKI_INSTANCE_URL, diagram_desc, language)
+            rendered_diagram = render_diagram(kroki_url, diagram_desc, language)
 
             # Replace the diagram description with the SVG representation
             diagram_desc.replace(rendered_diagram)
@@ -84,6 +86,21 @@ module Jekyll
           raise e.message
         else
           JSON.parse(response.body)["version"].keys if response.is_a?(Net::HTTPSuccess)
+        end
+      end
+
+      # Gets the URL of the Kroki instance to use for rendering diagrams.
+      #
+      # @param The Jekyll site configuration
+      # @return [URI::HTTP] The URL of the Kroki instance
+      def kroki_url(config)
+        if config.key?("jekyll-kroki") && config["jekyll-kroki"].key?("kroki_url")
+          url = config["jekyll-kroki"]["kroki_url"]
+          raise "'kroki_url' is not a valid HTTP URL" unless URI.parse(url).is_a?(URI::HTTP)
+
+          URI(url)
+        else
+          URI(KROKI_DEFAULT_URL)
         end
       end
 

--- a/test/jekyll/test_kroki.rb
+++ b/test/jekyll/test_kroki.rb
@@ -7,5 +7,27 @@ module Jekyll
     def test_that_it_has_a_version_number
       refute_nil ::Jekyll::Kroki::VERSION
     end
+
+    def test_valid_kroki_url
+      url = "https://rubygems.org/"
+      config = { "jekyll-kroki" => { "kroki_url" => url } }
+      assert_equal ::Jekyll::Kroki.kroki_url(config), URI(url)
+    end
+
+    def test_invalid_kroki_url
+      url = "ht//rubygems.org/"
+      config = { "jekyll-kroki" => { "kroki_url" => url } }
+      assert_raises(TypeError) { ::Jekyll::Kroki.kroki_url(config) }
+    end
+
+    def test_missing_kroki_url
+      config = { "jekyll-kroki" => { "pi" => 3.14 } }
+      assert_equal ::Jekyll::Kroki.kroki_url(config), URI("https://kroki.io")
+    end
+
+    def test_missing_kroki_config
+      config = { "jekyll-another-plugin" => { "pi" => 3.14 } }
+      assert_equal ::Jekyll::Kroki.kroki_url(config), URI("https://kroki.io")
+    end
   end
 end


### PR DESCRIPTION
Allows the URL of the Kroki instance to be specified in the Jekyll configuration file `_config.yml`:

```yaml
jekyll-kroki:
  kroki_url: "https://my-kroki.server"
```

If no URL is specified, `jekyll-kroki` will fall back to the default public Kroki instance https://kroki.io.

Closes #1