### PR TITLE
Simplify configuration naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The site remains truly static as the SVG is directly embedded in the HTML files 
 You can specify the URL of the Kroki instance to use in the Jekyll `_config.yml` file:
 
 ```yaml
-jekyll-kroki:
-  kroki_url: "https://my-kroki.server"
+kroki:
+  url: "https://my-kroki.server"
 ```
 
 This is useful if you want to run a Kroki instance locally or your organisation maintains its own private Kroki server. `jekyll-kroki` will use the public Kroki instance https://kroki.io by default if a URL is not specified.

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -130,9 +130,9 @@ module Jekyll
       # @param The Jekyll site configuration
       # @return [URI::HTTP] The URL of the Kroki instance
       def kroki_url(config)
-        if config.key?("jekyll-kroki") && config["jekyll-kroki"].key?("kroki_url")
-          url = config["jekyll-kroki"]["kroki_url"]
-          raise TypeError, "'kroki_url' is not a valid HTTP URL" unless URI.parse(url).is_a?(URI::HTTP)
+        if config.key?("kroki") && config["kroki"].key?("url")
+          url = config["kroki"]["url"]
+          raise TypeError, "'url' is not a valid HTTP URL" unless URI.parse(url).is_a?(URI::HTTP)
 
           URI(url)
         else

--- a/test/jekyll/test_kroki.rb
+++ b/test/jekyll/test_kroki.rb
@@ -10,23 +10,23 @@ module Jekyll
 
     def test_valid_kroki_url
       url = "https://rubygems.org/"
-      config = { "jekyll-kroki" => { "kroki_url" => url } }
+      config = { "kroki" => { "url" => url } }
       assert_equal ::Jekyll::Kroki.kroki_url(config), URI(url)
     end
 
     def test_invalid_kroki_url
       url = "ht//rubygems.org/"
-      config = { "jekyll-kroki" => { "kroki_url" => url } }
+      config = { "kroki" => { "url" => url } }
       assert_raises(TypeError) { ::Jekyll::Kroki.kroki_url(config) }
     end
 
     def test_missing_kroki_url
-      config = { "jekyll-kroki" => { "pi" => 3.14 } }
+      config = { "kroki" => { "pi" => 3.14 } }
       assert_equal ::Jekyll::Kroki.kroki_url(config), URI("https://kroki.io")
     end
 
     def test_missing_kroki_config
-      config = { "jekyll-another-plugin" => { "pi" => 3.14 } }
+      config = { "another-plugin" => { "pi" => 3.14 } }
       assert_equal ::Jekyll::Kroki.kroki_url(config), URI("https://kroki.io")
     end
   end


### PR DESCRIPTION
Simplifies the naming of the configuration options from:

```yaml
jekyll-kroki:
  kroki_url: "https://my-kroki.server"
```

to:

```yaml
kroki:
  url: "https://my-kroki.server"
```

Closes #9