### PR TITLE
Define array of supported languages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,10 +30,10 @@ GEM
       faraday (~> 2.0)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.0-x86_64-linux)
+    google-protobuf (3.25.1-x86_64-linux)
     http-2-next (1.0.1)
     http_parser.rb (0.8.0)
-    httpx (1.1.1)
+    httpx (1.1.3)
       http-2-next (>= 1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -69,7 +69,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     minitest (5.20.0)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
@@ -77,7 +77,7 @@ GEM
       racc
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
@@ -121,4 +121,4 @@ DEPENDENCIES
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.2.33
+   2.4.22


### PR DESCRIPTION
Determines which diagram scripting languages are supported by Kroki based on a hard-coded array instead of querying the Kroki server. This avoids the need for a Kroki server to be available even when generating a Jekyll site that contains no diagram descriptions.