### PR TITLE
Show rendered diagram count

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-kroki (0.2.2)
+    jekyll-kroki (0.3.0)
       faraday (~> 2.7)
       faraday-retry (~> 2.2)
       httpx (~> 1.1)
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
@@ -21,7 +21,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.7.11)
+    faraday (2.7.12)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -33,7 +33,7 @@ GEM
     google-protobuf (3.25.1-x86_64-linux)
     http-2-next (1.0.1)
     http_parser.rb (0.8.0)
-    httpx (1.1.3)
+    httpx (1.1.5)
       http-2-next (>= 1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -57,7 +57,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.6.3)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -84,10 +84,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     rexml (3.2.6)
     rouge (4.2.0)
-    rubocop (1.57.2)
+    rubocop (1.58.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -95,7 +95,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -121,4 +121,4 @@ DEPENDENCIES
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.4.22
+   2.2.33

--- a/lib/jekyll/kroki/version.rb
+++ b/lib/jekyll/kroki/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   class Kroki
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
Shows the number of rendered diagrams at the end of the Jekyll build process, e.g.:

```
[jekyll-kroki] Rendered 4 diagrams using Kroki instance at 'https://kroki.io/'
```