### PR TITLE
Return non-zero exit code after error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+    - name: Update Bundler
+      run: gem update bundler
     - name: Run the default task
       run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0.2'
+          - '3.0.6'
 
     steps:
     - uses: actions/checkout@v4
@@ -23,7 +23,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Update Bundler
-      run: gem update bundler
     - name: Run the default task
       run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-kroki (0.2.2)
+    jekyll-kroki (0.3.0)
       faraday (~> 2.7)
       faraday-retry (~> 2.2)
       httpx (~> 1.1)
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
@@ -21,7 +21,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.7.11)
+    faraday (2.7.12)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -33,7 +33,7 @@ GEM
     google-protobuf (3.25.1-x86_64-linux)
     http-2-next (1.0.1)
     http_parser.rb (0.8.0)
-    httpx (1.1.3)
+    httpx (1.1.5)
       http-2-next (>= 1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -57,7 +57,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.6.3)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -84,10 +84,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     rexml (3.2.6)
     rouge (4.2.0)
-    rubocop (1.57.2)
+    rubocop (1.58.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -95,7 +95,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -121,4 +121,4 @@ DEPENDENCIES
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.4.22
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-kroki (0.3.0)
+    jekyll-kroki (0.3.1)
       faraday (~> 2.7)
       faraday-retry (~> 2.2)
       httpx (~> 1.1)
@@ -14,30 +14,30 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    base64 (0.2.0)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.7.12)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     faraday-retry (2.2.0)
       faraday (~> 2.0)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.1-x86_64-linux)
-    http-2-next (1.0.1)
+    google-protobuf (3.25.2-arm64-darwin)
+    google-protobuf (3.25.2-x86_64-darwin)
+    google-protobuf (3.25.2-x86_64-linux)
+    http-2-next (1.0.3)
     http_parser.rb (0.8.0)
-    httpx (1.1.5)
-      http-2-next (>= 1.0.1)
+    httpx (1.2.2)
+      http-2-next (>= 1.0.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -68,11 +68,17 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    minitest (5.20.0)
-    nokogiri (1.15.5-x86_64-linux)
+    minitest (5.22.2)
+    net-http (0.4.1)
+      uri
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
-    parallel (1.23.0)
-    parser (3.2.2.4)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
+      racc (~> 1.4)
+    parallel (1.24.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pathutil (0.16.2)
@@ -84,14 +90,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.8.3)
+    regexp_parser (2.9.0)
     rexml (3.2.6)
     rouge (4.2.0)
-    rubocop (1.58.0)
+    rubocop (1.60.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -101,17 +107,23 @@ GEM
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
     sass-embedded (1.69.5)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
+    sass-embedded (1.69.5-arm64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-darwin)
+      google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES
@@ -121,4 +133,4 @@ DEPENDENCIES
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.2.33
+   2.5.6

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -76,9 +76,7 @@ module Jekyll
         begin
           response = connection.get("#{language}/svg/#{encode_diagram(diagram_desc.text)}")
         rescue Faraday::Error => e
-          raise "'#{connection.url_prefix}' does not point to a valid Kroki instance" if e.response.nil?
-
-          raise e.response[:body]
+          raise e.message
         end
         expected_content_type = "image/svg+xml"
         returned_content_type = response.headers[:content_type]
@@ -163,7 +161,7 @@ module Jekyll
         file, line_number, caller = e.backtrace[caller_index].split(":")
         caller = caller.tr("`", "'")
         warn %([jekyll-kroki] "#{error.message}" #{caller} on line #{line_number} of #{file}).red
-        exec "echo ''"
+        exec "exit 1"
       end
     end
   end

--- a/lib/jekyll/kroki/version.rb
+++ b/lib/jekyll/kroki/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   class Kroki
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/lib/jekyll/kroki/version.rb
+++ b/lib/jekyll/kroki/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   class Kroki
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
Returns `1` if an error occurs that causes the script to fail:

```shell
[jekyll-kroki] "SSL_connect returned=1 errno=0 state=error: certificate verify failed (certificate has expired)" in 'render_diagram' on line 76 of /workspaces/jekyll-kroki/lib/jekyll/kroki.rb
$ echo $?
1
```

Closes #19