### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Ruby
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/felixvanoost/jekyll-kroki/security/code-scanning/2](https://github.com/felixvanoost/jekyll-kroki/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not appear to require write permissions, we can set the `contents` permission to `read`. This will restrict the `GITHUB_TOKEN` to read-only access to repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. This ensures consistency and avoids the need to repeat the permissions block for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
