### PR TITLE
Apply performance optimisations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Ruby",
-	"image": "mcr.microsoft.com/devcontainers/ruby:4.0-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/ruby:3.4-bullseye",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -55,34 +55,22 @@ module Jekyll
         rendered_diag = 0
         semaphore = Async::Semaphore.new(max_concurrent_docs)
 
-        Async do |task|
+        Async do
           tasks = (site.pages + site.documents).filter_map do |doc|
             next unless embeddable?(doc)
 
-            async_embed_single_doc(task, semaphore, connection, doc)
+            semaphore.async do
+              embed_single_doc(connection, doc)
+            rescue StandardError => e
+              warn "[jekyll-kroki] Error rendering diagram: #{e.message}".red
+              0
+            end
           end
 
           rendered_diag = tasks.sum(&:wait)
         end
 
         rendered_diag
-      end
-
-      # Renders the supported diagram descriptions in a single document. Multiple documents can be rendered concurrently
-      # up to the limit imposed by the given semaphore.
-      #
-      # @param [Async::Task] The parent async task to spawn a child task from.
-      # @param [Async::Semaphore] A semaphore to limit concurrency.
-      # @param [Faraday::Connection] The Faraday connection to use.
-      # @param [Jekyll::Page, Jekyll::Document] The document to process.
-      # @return [Integer] The number of successfully rendered diagrams.
-      def async_embed_single_doc(task, semaphore, connection, doc)
-        task.async do
-          semaphore.async { embed_single_doc(connection, doc) }.wait
-        rescue StandardError => e
-          warn "[jekyll-kroki] Error rendering diagram: #{e.message}".red
-          0
-        end
       end
 
       # Renders the supported diagram descriptions in a single document sequentially and embeds them as inline SVGs in
@@ -161,7 +149,7 @@ module Jekyll
       # @param [String, #read] The diagram description to encode.
       # @return [String] The encoded diagram.
       def encode_diagram(diagram_desc)
-        Base64.urlsafe_encode64(Zlib.deflate(diagram_desc))
+        Base64.urlsafe_encode64(Zlib.deflate(diagram_desc, Zlib::BEST_COMPRESSION))
       end
 
       # Sets up a new Faraday connection.

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -85,7 +85,7 @@ module Jekyll
 
         nodes.each do |node|
           # Extract the diagram language from the class list.
-          language = node["class"].split.find { |c| c.start_with?("language-") }.delete_prefix("language-")
+          language = node["class"].split.grep(/\Alanguage-/).first.delete_prefix("language-")
           node.replace(render_diagram(connection, node.text, language))
         end
 

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -80,18 +80,19 @@ module Jekyll
       # @param [Jekyll::Page, Jekyll::Document] The document to process.
       # @return [Integer] The number of successfully rendered diagrams.
       def embed_single_doc(connection, doc)
-        # Parse the HTML document.
         parsed_doc = Nokogiri::HTML(doc.output)
 
+        # Create a single CSS query for all supported HTML tags and diagram languages.
+        selector = SUPPORTED_LANGUAGES.flat_map do |language|
+          EXPECTED_HTML_TAGS.map { |tag| "#{tag}[class~='language-#{language}']" }
+        end.join(", ")
+
         rendered_diag = 0
-        SUPPORTED_LANGUAGES.each do |language|
-          EXPECTED_HTML_TAGS.each do |tag|
-            parsed_doc.css("#{tag}[class~='language-#{language}']").each do |diagram_desc|
-              # Replace the diagram description with the SVG representation rendered by Kroki.
-              diagram_desc.replace(render_diagram(connection, diagram_desc, language))
-              rendered_diag += 1
-            end
-          end
+        parsed_doc.css(selector).each do |node|
+          # Extract the diagram language from the class list.
+          language = node["class"].split.find { |c| c.start_with?("language-") }.delete_prefix("language-")
+          node.replace(render_diagram(connection, node, language))
+          rendered_diag += 1
         end
 
         # Convert the document back to HTML.

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -86,7 +86,7 @@ module Jekyll
         nodes.each do |node|
           # Extract the diagram language from the class list.
           language = node["class"].split.find { |c| c.start_with?("language-") }.delete_prefix("language-")
-          node.replace(render_diagram(connection, node, language))
+          node.replace(render_diagram(connection, node.text, language))
         end
 
         # Convert the document back to HTML.
@@ -101,17 +101,14 @@ module Jekyll
       # @param [String] The diagram description.
       # @param [String] The language of the diagram description.
       # @return [String] The rendered diagram in SVG format.
-      def render_diagram(connection, diagram_desc, language)
-        diagram_text = diagram_desc.text
+      def render_diagram(connection, diagram_text, language)
         cache_key = "#{language}:#{Digest::SHA1.hexdigest(diagram_text)}"
         @diagram_cache.compute_if_absent(cache_key) do
-          begin
-            response = connection.get("#{language}/svg/#{encode_diagram(diagram_text)}")
-          rescue Faraday::Error => e
-            raise e.message
-          end
+          response = connection.get("#{language}/svg/#{encode_diagram(diagram_text)}")
           validate_content_type(response)
           sanitise_diagram(response.body)
+        rescue Faraday::Error => e
+          raise e.message
         end
       end
 
@@ -123,7 +120,7 @@ module Jekyll
         returned_content_type = response.headers[:content_type]
         return if returned_content_type == expected_content_type
 
-        raise "Kroki returned an incorrect content type: " \
+        raise "[jekyll-kroki] Kroki returned an incorrect content type: " \
               "expected '#{expected_content_type}', received '#{returned_content_type}'"
       end
 

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -18,13 +18,17 @@ require "zlib"
 module Jekyll
   # Converts diagram descriptions into images using Kroki.
   class Kroki
-    EXPECTED_HTML_TAGS = %w[code div].freeze
-    HTTP_RETRY_INTERVAL_BACKOFF_FACTOR = 2
-    HTTP_RETRY_INTERVAL_RANDOMNESS = 0.5
-    HTTP_RETRY_INTERVAL = 0.1
     SUPPORTED_LANGUAGES = %w[actdiag blockdiag bpmn bytefield c4plantuml d2 dbml diagramsnet ditaa erd excalidraw
                              graphviz mermaid nomnoml nwdiag packetdiag pikchr plantuml rackdiag seqdiag structurizr
                              svgbob symbolator tikz umlet vega vegalite wavedrom wireviz].freeze
+    EXPECTED_HTML_TAGS = %w[code div].freeze
+    DIAGRAM_SELECTOR = SUPPORTED_LANGUAGES.flat_map do |language|
+      EXPECTED_HTML_TAGS.map { |tag| "#{tag}[class~='language-#{language}']" }
+    end.join(", ").freeze
+
+    HTTP_RETRY_INTERVAL_BACKOFF_FACTOR = 2
+    HTTP_RETRY_INTERVAL_RANDOMNESS = 0.5
+    HTTP_RETRY_INTERVAL = 0.1
 
     @diagram_cache = Concurrent::Map.new
 
@@ -74,30 +78,25 @@ module Jekyll
       end
 
       # Renders the supported diagram descriptions in a single document sequentially and embeds them as inline SVGs in
-      # the HTML source.
+      # the HTML source. Returns without modifying the document if no supported diagram descriptions are found.
       #
       # @param [Faraday::Connection] The Faraday connection to use.
       # @param [Jekyll::Page, Jekyll::Document] The document to process.
       # @return [Integer] The number of successfully rendered diagrams.
       def embed_single_doc(connection, doc)
         parsed_doc = Nokogiri::HTML(doc.output)
+        nodes = parsed_doc.css(DIAGRAM_SELECTOR)
+        return 0 if nodes.empty?
 
-        # Create a single CSS query for all supported HTML tags and diagram languages.
-        selector = SUPPORTED_LANGUAGES.flat_map do |language|
-          EXPECTED_HTML_TAGS.map { |tag| "#{tag}[class~='language-#{language}']" }
-        end.join(", ")
-
-        rendered_diag = 0
-        parsed_doc.css(selector).each do |node|
+        nodes.each do |node|
           # Extract the diagram language from the class list.
           language = node["class"].split.find { |c| c.start_with?("language-") }.delete_prefix("language-")
           node.replace(render_diagram(connection, node, language))
-          rendered_diag += 1
         end
 
         # Convert the document back to HTML.
         doc.output = parsed_doc.to_html
-        rendered_diag
+        nodes.size
       end
 
       # Renders a single diagram description using Kroki. The rendered diagram is cached to avoid redundant HTTP

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -56,25 +56,20 @@ module Jekyll
       # @param [Integer] The maximum number of documents to render concurrently.
       # @return [Integer] The number of successfully rendered diagrams.
       def embed_docs_in_site(site, connection, max_concurrent_docs)
-        rendered_diag = 0
         semaphore = Async::Semaphore.new(max_concurrent_docs)
 
         Async do
-          tasks = (site.pages + site.documents).filter_map do |doc|
+          (site.pages + site.documents).filter_map do |doc|
             next unless embeddable?(doc)
 
             semaphore.async do
               embed_single_doc(connection, doc)
             rescue StandardError => e
-              warn "[jekyll-kroki] Error rendering diagram: #{e.message}".red
+              warn "[jekyll-kroki] Error rendering diagram: #{e.message}"
               0
             end
-          end
-
-          rendered_diag = tasks.sum(&:wait)
-        end
-
-        rendered_diag
+          end.sum(&:wait)
+        end.wait
       end
 
       # Renders the supported diagram descriptions in a single document sequentially and embeds them as inline SVGs in

--- a/test/jekyll/test_kroki.rb
+++ b/test/jekyll/test_kroki.rb
@@ -248,12 +248,11 @@ module Jekyll
 
     def test_render_diagram_success
       diagram_text = "graph TD; A-->B;"
-      diagram_desc = diagram_desc_mock(diagram_text)
       response = svg_response
 
       @connection.expect(:get, response, ["mermaid/svg/#{encode(diagram_text)}"])
 
-      result = ::Jekyll::Kroki.render_diagram(@connection, diagram_desc, "mermaid")
+      result = ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
 
       assert_equal "<?xml version=\"1.0\"?>\n<svg/>\n", result
       @connection.verify
@@ -261,11 +260,10 @@ module Jekyll
 
     def test_render_diagram_failure
       diagram_text = "graph TD; A-->B;"
-      diagram_desc = diagram_desc_mock(diagram_text)
       @connection.expect(:get, nil) { raise "Connection failed" }
 
       assert_raises(RuntimeError) do
-        ::Jekyll::Kroki.render_diagram(@connection, diagram_desc, "mermaid")
+        ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
       end
 
       @connection.verify
@@ -273,7 +271,6 @@ module Jekyll
 
     def test_render_diagram_incorrect_content_type
       diagram_text = "graph TD; A-->B;"
-      diagram_desc = diagram_desc_mock(diagram_text)
       response = Minitest::Mock.new
       response.expect(:headers, { content_type: "text/html" })
       response.expect(:body, "<?xml version=\"1.0\"?>\n<svg/>\n")
@@ -281,7 +278,7 @@ module Jekyll
       @connection.expect(:get, response, ["mermaid/svg/#{encode(diagram_text)}"])
 
       assert_raises(RuntimeError) do
-        ::Jekyll::Kroki.render_diagram(@connection, diagram_desc, "mermaid")
+        ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
       end
 
       @connection.verify
@@ -289,46 +286,38 @@ module Jekyll
 
     def test_render_diagram_is_cached_after_first_call
       diagram_text = "graph TD; A-->B;"
-      desc_first  = diagram_desc_mock(diagram_text)
-      desc_second = diagram_desc_mock(diagram_text)
       @connection.expect(:get, svg_response, ["mermaid/svg/#{encode(diagram_text)}"])
 
-      first_result  = ::Jekyll::Kroki.render_diagram(@connection, desc_first,  "mermaid")
-      second_result = ::Jekyll::Kroki.render_diagram(@connection, desc_second, "mermaid")
+      first_result  = ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
+      second_result = ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
 
       assert_equal first_result, second_result
       # Verifying the mock ensures :get was called exactly once — a second call
       # would raise a MockExpectationError because no further :get is expected.
       @connection.verify
-      desc_first.verify
-      desc_second.verify
     end
 
     def test_cache_is_keyed_per_language
       diagram_text = "graph TD; A-->B;"
       encoded = encode(diagram_text)
-      desc_mermaid  = diagram_desc_mock(diagram_text)
-      desc_graphviz = diagram_desc_mock(diagram_text)
       @connection.expect(:get, svg_response("mermaid"),  ["mermaid/svg/#{encoded}"])
       @connection.expect(:get, svg_response("graphviz"), ["graphviz/svg/#{encoded}"])
 
-      mermaid_result  = ::Jekyll::Kroki.render_diagram(@connection, desc_mermaid,  "mermaid")
-      graphviz_result = ::Jekyll::Kroki.render_diagram(@connection, desc_graphviz, "graphviz")
+      mermaid_result  = ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
+      graphviz_result = ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "graphviz")
 
       refute_equal mermaid_result, graphviz_result
       @connection.verify
     end
 
     def test_cache_is_keyed_per_diagram_text
-      text_a = "graph TD; A-->B;"
-      text_b = "graph TD; X-->Y;"
-      desc_a = diagram_desc_mock(text_a)
-      desc_b = diagram_desc_mock(text_b)
-      @connection.expect(:get, svg_response("a"), ["mermaid/svg/#{encode(text_a)}"])
-      @connection.expect(:get, svg_response("b"), ["mermaid/svg/#{encode(text_b)}"])
+      diagram_text_a = "graph TD; A-->B;"
+      diagram_text_b = "graph TD; X-->Y;"
+      @connection.expect(:get, svg_response("a"), ["mermaid/svg/#{encode(diagram_text_a)}"])
+      @connection.expect(:get, svg_response("b"), ["mermaid/svg/#{encode(diagram_text_b)}"])
 
-      result_a = ::Jekyll::Kroki.render_diagram(@connection, desc_a, "mermaid")
-      result_b = ::Jekyll::Kroki.render_diagram(@connection, desc_b, "mermaid")
+      result_a = ::Jekyll::Kroki.render_diagram(@connection, diagram_text_a, "mermaid")
+      result_b = ::Jekyll::Kroki.render_diagram(@connection, diagram_text_b, "mermaid")
 
       refute_equal result_a, result_b
       @connection.verify

--- a/test/jekyll/test_kroki.rb
+++ b/test/jekyll/test_kroki.rb
@@ -355,7 +355,7 @@ module Jekyll
     end
 
     def encode(text)
-      Base64.urlsafe_encode64(Zlib.deflate(text))
+      Base64.urlsafe_encode64(Zlib.deflate(text, Zlib::BEST_COMPRESSION))
     end
   end
 
@@ -374,7 +374,7 @@ module Jekyll
       response.expect(:headers, { content_type: "image/svg+xml" })
       response.expect(:body, "<?xml version=\"1.0\"?>\n<svg/>\n")
 
-      encoded_diagram = Base64.urlsafe_encode64(Zlib.deflate("graph TD; A-->B;"))
+      encoded_diagram = Base64.urlsafe_encode64(Zlib.deflate("graph TD; A-->B;", Zlib::BEST_COMPRESSION))
       @connection.expect(:get, response, ["mermaid/svg/#{encoded_diagram}"])
 
       rendered_diag = ::Jekyll::Kroki.embed_single_doc(@connection, doc)
@@ -388,7 +388,7 @@ module Jekyll
       connection = Minitest::Mock.new
 
       response = setup_mock_response
-      encoded_diagram = Base64.urlsafe_encode64(Zlib.deflate("graph TD; A-->B;"))
+      encoded_diagram = Base64.urlsafe_encode64(Zlib.deflate("graph TD; A-->B;", Zlib::BEST_COMPRESSION))
       connection.expect(:get, response, ["mermaid/svg/#{encoded_diagram}"])
 
       ::Jekyll::Kroki.stub(:setup_connection, connection) do
@@ -481,7 +481,7 @@ module Jekyll
     end
 
     def setup_two_doc_site(diagram_text)
-      encoded = Base64.urlsafe_encode64(Zlib.deflate(diagram_text))
+      encoded = Base64.urlsafe_encode64(Zlib.deflate(diagram_text, Zlib::BEST_COMPRESSION))
 
       site = Minitest::Mock.new
       config = { "kroki" => { "url" => "https://kroki.io" } }


### PR DESCRIPTION
- Uses the best deflate compression (level 9) as recommended in the Kroki documentation.
- Searches for diagrams using a single CSS query.
- Avoids re-rendering the HTML for a document if no Kroki-supported diagrams are found within.
- Simplifies the `async` logic and the return logic in `embed_docs_in_site`.