### PR TITLE
Handle exceptions gracefully

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
     "editor.rulers": [
         120
     ],
-    "rubyLsp.formatter": "rubocop"
+    "rubyLsp.formatter": "rubocop",
+    "cSpell.language": "en-GB",
+    "cSpell.words": [
+        "Kroki"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Instead of using Liquid tags, `jekyll-kroki` leverages the same Markdown fenced 
 
 #### Seamless GitLab integration
 
-Self-managed GitLab instances can additionally enable the [Kroki integration](https://docs.gitlab.com/ee/administration/integration/kroki.html), which adds support for all the same diagram scripting languages used by `jekyll-kroki`. Furthermore, by pointing both GitLab and `jekyll-kroki` to the same Kroki instance, you can guarantee that diagrams are generated using identical versions of the diagram libraries.
+Self-managed or dedicated GitLab instances can additionally enable the [Kroki integration](https://docs.gitlab.com/ee/administration/integration/kroki.html), which adds support for all the diagram scripting languages used by `jekyll-kroki`. Furthermore, by pointing both GitLab and `jekyll-kroki` to the same Kroki instance, you can guarantee that diagrams are generated using identical versions of the diagram libraries.
 
 #### Speed
 
-The server-side nature of Kroki means that you don't have to deal with installing or updating any diagram library dependencies on your machine. Jekyll sites that are generated in CI/CD pipelines can bypass these steps and will thus build faster.
+The server-side nature of Kroki means that you don't have to deal with installing or updating any diagram library dependencies on your machine. Jekyll sites that are generated in CI/CD pipelines can bypass these setup steps and will thus build faster. `jekyll-kroki` is built with performance in mind to minimise the build time of even the largest sites with thousands of diagrams.
 
 #### Flexibility
 
@@ -78,7 +78,7 @@ kroki:
 
 ### Security
 
-Embedding diagrams as SVGs directly within HTML files can be dangerous. You should only use a Kroki instance that you trust (or run your own!). For additional security, you can configure a [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) using custom Webrick headers in the Jekyll `_config.yml` file:
+Embedding untrusted SVGs directly in HTML files can introduce security risks. Use a Kroki instance that you trust, or consider hosting your own local/private instance. For added security, you can configure a [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) by adding custom Webrick headers in your Jekyll `_config.yml` file:
 
 ```yaml
 webrick:

--- a/lib/jekyll/kroki.rb
+++ b/lib/jekyll/kroki.rb
@@ -41,11 +41,11 @@ module Jekyll
         connection = setup_connection(config.kroki_url, config.http_retries, config.http_timeout)
 
         rendered_diag = embed_docs_in_site(site, connection, config.max_concurrent_docs)
-        unless rendered_diag.zero?
-          puts "[jekyll-kroki] Rendered #{rendered_diag} diagrams using Kroki instance at '#{config.kroki_url}'"
-        end
-      rescue StandardError => e
-        fatal_error(e)
+        return unless rendered_diag.positive?
+
+        Jekyll.logger.info(
+          "[jekyll-kroki] Rendered #{rendered_diag} diagrams using Kroki instance at '#{config.kroki_url}'"
+        )
       end
 
       # Renders the diagram descriptions in all Jekyll pages and documents in the given Jekyll site. Pages / documents
@@ -65,7 +65,7 @@ module Jekyll
             semaphore.async do
               embed_single_doc(connection, doc)
             rescue StandardError => e
-              warn "[jekyll-kroki] Error rendering diagram: #{e.message}".red
+              Jekyll.logger.error "[jekyll-kroki] Failed to render diagram in '#{doc.relative_path}': #{e.message}"
               0
             end
           end.sum(&:wait)
@@ -107,8 +107,9 @@ module Jekyll
           response = connection.get("#{language}/svg/#{encode_diagram(diagram_text)}")
           validate_content_type(response)
           sanitise_diagram(response.body)
-        rescue Faraday::Error => e
-          raise e.message
+        rescue Faraday::BadRequestError => e
+          kroki_message = e.response_body.to_s.strip
+          raise e, (kroki_message.empty? ? e.message : kroki_message)
         end
       end
 
@@ -127,7 +128,7 @@ module Jekyll
       # Sanitises a rendered diagram. Only <script> elements are removed, which is the most minimal / naive
       # implementation possible.
       #
-      # @param [String] The diagram to santise in SVG format.
+      # @param [String] The diagram to sanitise in SVG format.
       # @return [String] The sanitised diagram.
       def sanitise_diagram(diagram_svg)
         parsed_svg = Nokogiri::XML(diagram_svg)
@@ -171,27 +172,13 @@ module Jekyll
       def embeddable?(doc)
         doc.output_ext == ".html" && (doc.is_a?(Jekyll::Page) || doc.write?)
       end
-
-      # Exits the Jekyll process without returning a stack trace. This method does not return because the process is
-      # abruptly terminated.
-      #
-      # @param [StandardError] The error to display in the termination message.
-      # @param [int] The caller index to display in the termination message. The default index is 1, which means the
-      #              calling method. To specify the calling method's caller, pass in 2.
-      #
-      # Source: https://www.mslinn.com/ruby/2200-crash-exit.html
-      def fatal_error(error, caller_index = 1)
-        raise error
-      rescue StandardError => e
-        file, line_number, caller = e.backtrace[caller_index].split(":")
-        caller = caller.tr("", "'")
-        warn %([jekyll-kroki] "#{error.message}" #{caller} on line #{line_number} of #{file}).red
-        exec "exit 1"
-      end
     end
   end
 end
 
 Jekyll::Hooks.register :site, :post_render do |site|
   Jekyll::Kroki.embed_site(site)
+rescue StandardError => e
+  Jekyll.logger.error "[jekyll-kroki] #{e.class}: #{e.message}"
+  raise
 end

--- a/test/jekyll/test_kroki.rb
+++ b/test/jekyll/test_kroki.rb
@@ -9,6 +9,31 @@ require "base64"
 require "zlib"
 
 module Jekyll
+  module KrokiTestHelpers
+    def encode(text)
+      Base64.urlsafe_encode64(Zlib.deflate(text, Zlib::BEST_COMPRESSION))
+    end
+
+    def svg_response(id = nil)
+      body = id ? "<?xml version=\"1.0\"?>\n<svg id='#{id}'/>\n" : "<?xml version=\"1.0\"?>\n<svg/>\n"
+      response = Minitest::Mock.new
+      response.expect(:headers, { content_type: "image/svg+xml" })
+      response.expect(:body, body)
+      response
+    end
+
+    def create_mock_doc(diagram_text, relative_path = "index.md")
+      doc = Minitest::Mock.new
+      doc.expect(:output_ext, ".html")
+      doc.expect(:is_a?, false, [Jekyll::Page])
+      doc.expect(:write?, true)
+      doc.expect(:output, "<div class='language-mermaid'>#{diagram_text}</div>")
+      doc.expect(:output=, nil, [String])
+      doc.expect(:relative_path, relative_path)
+      doc
+    end
+  end
+
   class TestKrokiConfig < Minitest::Test
     def test_valid_kroki_url
       url = "https://rubygems.org/"
@@ -29,6 +54,12 @@ module Jekyll
       assert_raises(TypeError) { Jekyll::Kroki::Config.new(config) }
     end
 
+    def test_https_kroki_url_is_accepted
+      config = { "kroki" => { "url" => "https://kroki.example.com" } }
+
+      assert_instance_of URI::HTTPS, Jekyll::Kroki::Config.new(config).kroki_url
+    end
+
     def test_missing_kroki_url
       config = { "kroki" => { "pi" => 3.14 } }
 
@@ -41,19 +72,22 @@ module Jekyll
       assert_equal URI("https://kroki.io"), Jekyll::Kroki::Config.new(config).kroki_url
     end
 
-    # --- http_retries ---
+    def test_empty_site_config
+      config = {}
+
+      cfg = Jekyll::Kroki::Config.new(config)
+
+      assert_equal URI("https://kroki.io"), cfg.kroki_url
+      assert_equal Jekyll::Kroki::Config::DEFAULT_HTTP_RETRIES, cfg.http_retries
+      assert_equal Jekyll::Kroki::Config::DEFAULT_HTTP_TIMEOUT, cfg.http_timeout
+      assert_equal Jekyll::Kroki::Config::DEFAULT_MAX_CONCURRENT_DOCS, cfg.max_concurrent_docs
+    end
 
     def test_valid_http_retries
       retries = 5
       config = { "kroki" => { "http_retries" => retries } }
 
       assert_equal retries, Jekyll::Kroki::Config.new(config).http_retries
-    end
-
-    def test_default_http_retries
-      config = {}
-
-      assert_equal Jekyll::Kroki::Config::DEFAULT_HTTP_RETRIES, Jekyll::Kroki::Config.new(config).http_retries
     end
 
     def test_zero_http_retries
@@ -74,19 +108,11 @@ module Jekyll
       assert_raises(TypeError) { Jekyll::Kroki::Config.new(config) }
     end
 
-    # --- http_timeout ---
-
     def test_valid_http_timeout
       timeout = 30
       config = { "kroki" => { "http_timeout" => timeout } }
 
       assert_equal timeout, Jekyll::Kroki::Config.new(config).http_timeout
-    end
-
-    def test_default_http_timeout
-      config = {}
-
-      assert_equal Jekyll::Kroki::Config::DEFAULT_HTTP_TIMEOUT, Jekyll::Kroki::Config.new(config).http_timeout
     end
 
     def test_zero_http_timeout_is_valid
@@ -107,20 +133,11 @@ module Jekyll
       assert_raises(TypeError) { Jekyll::Kroki::Config.new(config) }
     end
 
-    # --- max_concurrent_docs ---
-
     def test_valid_max_concurrent_docs
       max_concurrent = 4
       config = { "kroki" => { "max_concurrent_docs" => max_concurrent } }
 
       assert_equal max_concurrent, Jekyll::Kroki::Config.new(config).max_concurrent_docs
-    end
-
-    def test_default_max_concurrent_docs
-      config = {}
-
-      assert_equal Jekyll::Kroki::Config::DEFAULT_MAX_CONCURRENT_DOCS,
-                   Jekyll::Kroki::Config.new(config).max_concurrent_docs
     end
 
     def test_zero_max_concurrent_docs_raises
@@ -141,7 +158,11 @@ module Jekyll
       assert_raises(TypeError) { Jekyll::Kroki::Config.new(config) }
     end
 
-    # --- immutability ---
+    def test_one_max_concurrent_docs_is_valid
+      config = { "kroki" => { "max_concurrent_docs" => 1 } }
+
+      assert_equal 1, Jekyll::Kroki::Config.new(config).max_concurrent_docs
+    end
 
     def test_config_is_frozen
       assert_predicate Jekyll::Kroki::Config.new({}), :frozen?
@@ -149,7 +170,7 @@ module Jekyll
   end
 
   class TestKrokiEmbeddable < Minitest::Test
-    def test_embeddable_document
+    def test_embeddable_jekyll_page
       doc = Minitest::Mock.new
       doc.expect(:output_ext, ".html")
       doc.expect(:is_a?, true, [Jekyll::Page])
@@ -158,19 +179,38 @@ module Jekyll
       doc.verify
     end
 
-    def test_non_embeddable_document
+    def test_non_embeddable_non_html_document
       doc = Minitest::Mock.new
       doc.expect(:output_ext, ".md")
+      # output_ext returns ".md" so embeddable? short-circuits; is_a? must not be called.
 
       refute ::Jekyll::Kroki.embeddable?(doc)
       doc.verify
     end
 
-    def test_non_html_embeddable_document
+    def test_non_writable_html_document_is_not_embeddable
       doc = Minitest::Mock.new
       doc.expect(:output_ext, ".html")
       doc.expect(:is_a?, false, [Jekyll::Page])
       doc.expect(:write?, false)
+
+      refute ::Jekyll::Kroki.embeddable?(doc)
+      doc.verify
+    end
+
+    def test_writable_html_document_is_embeddable
+      doc = Minitest::Mock.new
+      doc.expect(:output_ext, ".html")
+      doc.expect(:is_a?, false, [Jekyll::Page])
+      doc.expect(:write?, true)
+
+      assert ::Jekyll::Kroki.embeddable?(doc)
+      doc.verify
+    end
+
+    def test_non_html_jekyll_page_is_not_embeddable
+      doc = Minitest::Mock.new
+      doc.expect(:output_ext, ".xml")
 
       refute ::Jekyll::Kroki.embeddable?(doc)
       doc.verify
@@ -187,18 +227,29 @@ module Jekyll
       assert_instance_of Faraday::Connection, connection
     end
 
-    def test_encode_diagram
+    def test_encode_diagram_is_reversible
       diagram_desc = "graph TD; A-->B;"
       encoded = ::Jekyll::Kroki.encode_diagram(diagram_desc)
 
       assert_instance_of String, encoded
+      decoded = Zlib.inflate(Base64.urlsafe_decode64(encoded))
+
+      assert_equal diagram_desc, decoded
     end
 
-    def test_sanitise_diagram
+    def test_sanitise_diagram_removes_script_tags
       diagram_svg = '<?xml version="1.0"?><svg><script>alert("test")</script></svg>'
       sanitised = ::Jekyll::Kroki.sanitise_diagram(diagram_svg)
 
       assert_equal "<?xml version=\"1.0\"?>\n<svg/>\n", sanitised
+    end
+
+    def test_sanitise_diagram_removes_nested_script_tags
+      diagram_svg = '<?xml version="1.0"?><svg><g><script>evil()</script></g></svg>'
+      sanitised = ::Jekyll::Kroki.sanitise_diagram(diagram_svg)
+
+      refute_includes sanitised, "<script"
+      refute_includes sanitised, "evil()"
     end
   end
 
@@ -211,7 +262,7 @@ module Jekyll
       response.verify
     end
 
-    def test_invalid_content_type
+    def test_invalid_content_type_error_message_names_both_types
       response = Minitest::Mock.new
       response.expect(:headers, { content_type: "text/html" })
 
@@ -221,7 +272,7 @@ module Jekyll
       response.verify
     end
 
-    def test_missing_content_type
+    def test_missing_content_type_raises
       response = Minitest::Mock.new
       response.expect(:headers, {})
 
@@ -229,7 +280,7 @@ module Jekyll
       response.verify
     end
 
-    def test_content_type_with_charset_suffix
+    def test_content_type_with_charset_suffix_currently_raises
       response = Minitest::Mock.new
       response.expect(:headers, { content_type: "image/svg+xml; charset=utf-8" })
 
@@ -239,6 +290,8 @@ module Jekyll
   end
 
   class TestKrokiRendering < Minitest::Test
+    include KrokiTestHelpers
+
     def setup
       @connection = Minitest::Mock.new
       # Reset the diagram cache before each test so that cached results from a previous
@@ -258,7 +311,7 @@ module Jekyll
       @connection.verify
     end
 
-    def test_render_diagram_failure
+    def test_render_diagram_raises_on_connection_failure
       diagram_text = "graph TD; A-->B;"
       @connection.expect(:get, nil) { raise "Connection failed" }
 
@@ -269,11 +322,12 @@ module Jekyll
       @connection.verify
     end
 
-    def test_render_diagram_incorrect_content_type
+    def test_render_diagram_raises_on_incorrect_content_type
       diagram_text = "graph TD; A-->B;"
+      # NOTE: body is stubbed here but will never be read because validate_content_type
+      # raises before the body is accessed. The expectation is kept for completeness.
       response = Minitest::Mock.new
       response.expect(:headers, { content_type: "text/html" })
-      response.expect(:body, "<?xml version=\"1.0\"?>\n<svg/>\n")
 
       @connection.expect(:get, response, ["mermaid/svg/#{encode(diagram_text)}"])
 
@@ -294,6 +348,25 @@ module Jekyll
       assert_equal first_result, second_result
       # Verifying the mock ensures :get was called exactly once — a second call
       # would raise a MockExpectationError because no further :get is expected.
+      @connection.verify
+    end
+
+    def test_failed_render_is_not_cached
+      diagram_text = "graph TD; A-->B;"
+
+      # First call raises.
+      @connection.expect(:get, nil) { raise "transient error" }
+      # Second call succeeds.
+      @connection.expect(:get, svg_response, ["mermaid/svg/#{encode(diagram_text)}"])
+
+      assert_raises(RuntimeError) do
+        ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
+      end
+
+      # Should succeed on retry without returning nil/stale cached value.
+      result = ::Jekyll::Kroki.render_diagram(@connection, diagram_text, "mermaid")
+
+      assert_includes result, "<svg"
       @connection.verify
     end
 
@@ -322,49 +395,22 @@ module Jekyll
       refute_equal result_a, result_b
       @connection.verify
     end
-
-    private
-
-    def diagram_desc_mock(text)
-      desc = Minitest::Mock.new
-      desc.expect(:text, text)
-      desc
-    end
-
-    def svg_response(id = nil)
-      svg_body = if id
-                   "<?xml version=\"1.0\"?>\n<svg id='#{id}'/>\n"
-                 else
-                   "<?xml version=\"1.0\"?>\n<svg/>\n"
-                 end
-      response = Minitest::Mock.new
-      response.expect(:headers, { content_type: "image/svg+xml" })
-      response.expect(:body, svg_body)
-      response
-    end
-
-    def encode(text)
-      Base64.urlsafe_encode64(Zlib.deflate(text, Zlib::BEST_COMPRESSION))
-    end
   end
 
   class TestKrokiEmbed < Minitest::Test
+    include KrokiTestHelpers
+
     def setup
       @connection = Minitest::Mock.new
       ::Jekyll::Kroki.instance_variable_set(:@diagram_cache, Concurrent::Map.new)
     end
 
-    def test_embed_single_doc
+    def test_embed_single_doc_returns_diagram_count
       doc = Minitest::Mock.new
       doc.expect(:output, "<div class='language-mermaid'>graph TD; A-->B;</div>")
       doc.expect(:output=, nil, [String])
 
-      response = Minitest::Mock.new
-      response.expect(:headers, { content_type: "image/svg+xml" })
-      response.expect(:body, "<?xml version=\"1.0\"?>\n<svg/>\n")
-
-      encoded_diagram = Base64.urlsafe_encode64(Zlib.deflate("graph TD; A-->B;", Zlib::BEST_COMPRESSION))
-      @connection.expect(:get, response, ["mermaid/svg/#{encoded_diagram}"])
+      @connection.expect(:get, svg_response, ["mermaid/svg/#{encode("graph TD; A-->B;")}"])
 
       rendered_diag = ::Jekyll::Kroki.embed_single_doc(@connection, doc)
 
@@ -372,58 +418,64 @@ module Jekyll
       @connection.verify
     end
 
+    def test_embed_single_doc_returns_zero_when_no_diagrams
+      doc = Minitest::Mock.new
+      doc.expect(:output, "<p>No diagrams here.</p>")
+
+      result = ::Jekyll::Kroki.embed_single_doc(@connection, doc)
+
+      assert_equal 0, result
+      doc.verify
+    end
+
+    def test_embed_single_doc_multiple_diagrams
+      mermaid_text  = "graph TD; A-->B;"
+      graphviz_text = "digraph G { A -> B }"
+      html = "<div class='language-mermaid'>#{mermaid_text}</div>" \
+             "<div class='language-graphviz'>#{graphviz_text}</div>"
+
+      doc = Minitest::Mock.new
+      doc.expect(:output, html)
+      doc.expect(:output=, nil, [String])
+
+      @connection.expect(:get, svg_response("m"), ["mermaid/svg/#{encode(mermaid_text)}"])
+      @connection.expect(:get, svg_response("g"), ["graphviz/svg/#{encode(graphviz_text)}"])
+
+      result = ::Jekyll::Kroki.embed_single_doc(@connection, doc)
+
+      assert_equal 2, result
+      @connection.verify
+      doc.verify
+    end
+
     def test_embed_site
       site = setup_mock_site
       connection = Minitest::Mock.new
-
-      response = setup_mock_response
-      encoded_diagram = Base64.urlsafe_encode64(Zlib.deflate("graph TD; A-->B;", Zlib::BEST_COMPRESSION))
-      connection.expect(:get, response, ["mermaid/svg/#{encoded_diagram}"])
+      connection.expect(:get, svg_response, ["mermaid/svg/#{encode("graph TD; A-->B;")}"])
 
       ::Jekyll::Kroki.stub(:setup_connection, connection) do
         ::Jekyll::Kroki.embed_site(site)
       end
 
-      verify_mocks(site, connection)
-    end
-
-    def test_embed_docs_concurrency_limit
-      site = Minitest::Mock.new
-      docs = Array.new(15) { |i| create_mock_doc("graph TD; A#{i}-->B#{i};") }
-      site.expect(:pages, [])
-      site.expect(:documents, docs)
-      max_concurrent_docs = 8
-
-      connection = Minitest::Mock.new
-      call_count = 0
-
-      Jekyll::Kroki.stub(:embed_single_doc, lambda { |_conn, _doc|
-        call_count += 1
-        1
-      }) do
-        Jekyll::Kroki.embed_docs_in_site(site, connection, max_concurrent_docs)
-      end
-
-      assert_equal 15, call_count
       site.verify
+      connection.verify
     end
 
-    def test_embed_docs_handles_errors
+    def test_embed_docs_handles_errors_in_individual_docs
       site = Minitest::Mock.new
       site.expect(:pages, [])
-      bad_doc = create_mock_doc("fail")
-      good_doc = create_mock_doc("graph TD; A-->B;")
+      bad_doc  = create_mock_doc("fail", "bad_doc.md")
+      good_doc = create_mock_doc("graph TD; A-->B;", "good_doc.md")
       site.expect(:documents, [bad_doc, good_doc])
       max_concurrent_docs = 8
-
-      connection = Minitest::Mock.new
 
       result = Jekyll::Kroki.stub(:embed_single_doc, lambda { |_conn, doc|
         doc.output.include?("fail") ? raise("bad!") : 1
       }) do
-        Jekyll::Kroki.embed_docs_in_site(site, connection, max_concurrent_docs)
+        Jekyll::Kroki.embed_docs_in_site(site, @connection, max_concurrent_docs)
       end
 
+      # One doc failed (counts as 0), one succeeded (counts as 1).
       assert_equal 1, result
       site.verify
     end
@@ -444,59 +496,25 @@ module Jekyll
 
     def setup_mock_site
       site = Minitest::Mock.new
-      config = { "kroki" => { "url" => "https://kroki.io" } }
-      site.expect(:config, config)
-
-      doc = Minitest::Mock.new
-      doc.expect(:output_ext, ".html")
-      doc.expect(:is_a?, false, [Jekyll::Page])
-      doc.expect(:write?, true)
-      doc.expect(:output, "<div class='language-mermaid'>graph TD; A-->B;</div>")
-      doc.expect(:output=, nil, [String])
-
+      site.expect(:config, { "kroki" => { "url" => "https://kroki.io" } })
       site.expect(:pages, [])
-      site.expect(:documents, [doc])
+      site.expect(:documents, [create_mock_doc("graph TD; A-->B;")])
       site
     end
 
-    def create_mock_doc(diagram_text)
-      doc = Minitest::Mock.new
-      doc.expect(:output_ext, ".html")
-      doc.expect(:is_a?, false, [Jekyll::Page])
-      doc.expect(:write?, true)
-      doc.expect(:output, "<div class='language-mermaid'>#{diagram_text}</div>")
-      doc.expect(:output=, nil, [String])
-      doc
-    end
-
     def setup_two_doc_site(diagram_text)
-      encoded = Base64.urlsafe_encode64(Zlib.deflate(diagram_text, Zlib::BEST_COMPRESSION))
-
       site = Minitest::Mock.new
-      config = { "kroki" => { "url" => "https://kroki.io" } }
-      site.expect(:config, config)
+      site.expect(:config, { "kroki" => { "url" => "https://kroki.io" } })
       site.expect(:pages, [])
-      site.expect(:documents, [create_mock_doc(diagram_text), create_mock_doc(diagram_text)])
+      site.expect(:documents, [
+                    create_mock_doc(diagram_text, "doc1.md"),
+                    create_mock_doc(diagram_text, "doc2.md")
+                  ])
 
       connection = Minitest::Mock.new
-      response = Minitest::Mock.new
-      response.expect(:headers, { content_type: "image/svg+xml" })
-      response.expect(:body, "<?xml version=\"1.0\"?>\n<svg/>\n")
-      connection.expect(:get, response, ["mermaid/svg/#{encoded}"])
+      connection.expect(:get, svg_response, ["mermaid/svg/#{encode(diagram_text)}"])
 
       [site, connection]
-    end
-
-    def setup_mock_response
-      response = Minitest::Mock.new
-      response.expect(:headers, { content_type: "image/svg+xml" })
-      response.expect(:body, "<?xml version=\"1.0\"?>\n<svg/>\n")
-      response
-    end
-
-    def verify_mocks(site, connection)
-      site.verify
-      connection.verify
     end
   end
 end


### PR DESCRIPTION
Handles exceptions in a more graceful way by:

- Raising exceptions up to Jekyll instead of killing the Jekyll process.
- Displaying text via `Jekyll.logger`.
- Displaying the error message returned by Kroki when available, which gives specific information about the problem (e.g. incorrect diagram syntax) instead of a generic exception name.